### PR TITLE
Update namecheap-ddns-update

### DIFF
--- a/namecheap-ddns-update
+++ b/namecheap-ddns-update
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+GLOBIGNORE="*"
 # for a domain you own hosted at namecheap, register one or more subdomains
 # to an IP address in namecheaps dynamicdns system
 


### PR DESCRIPTION
Allow wildcard subdomain. Prior to the patch, * was causing filename expansion