### PR TITLE
Automated multiarch docker builds with travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,5 +57,6 @@ matrix:
           /tmp/scripts.sh push_readme
           ${TRAVIS_REPO_SLUG} README.md
           ${DOCKER_USERNAME} ${DOCKER_PASSWORD}
+          
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+dist: bionic
+os: linux
+language: shell
+
+services:
+  - docker
+
+env:
+  global:
+    - DOCKER_PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6"
+
+git:
+  depth: 1
+
+before_install:
+  # Registering file format recognizers since RUN command is used
+  - sudo docker run --privileged linuxkit/binfmt:v0.7
+  # Get scripts for building Docker images
+  - id=$(docker create moikot/docker-tools)
+  - docker cp $id:/scripts.sh /tmp/scripts.sh && docker rm -v $id
+  # Update docker to the latest version and enable BuildKit
+  - /tmp/scripts.sh update_docker
+
+stages:
+  - name: build amd64
+    if: branch != master AND tag IS blank
+  - name: build and deploy master
+    if: branch = master AND tag IS blank
+  - name: build and deploy a version
+    if: tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+
+matrix:
+  include:
+
+    - stage: build amd64
+      script:
+        - >-
+          /tmp/scripts.sh build_images
+          ${TRAVIS_REPO_SLUG} ${TRAVIS_COMMIT::6} linux/amd64
+    - stage: build and deploy master
+      script:
+        - >-
+          echo "${DOCKER_PASSWORD}" |
+          docker login -u "${DOCKER_USERNAME}" --password-stdin
+        - >-
+          /tmp/scripts.sh build_images
+          ${TRAVIS_REPO_SLUG} master ${DOCKER_PLATFORMS} --push
+    - stage: build and deploy a version
+      script:
+        - >-
+          echo "${DOCKER_PASSWORD}" |
+          docker login -u "${DOCKER_USERNAME}" --password-stdin
+        - >-
+          /tmp/scripts.sh build_images
+          ${TRAVIS_REPO_SLUG} ${TRAVIS_TAG} ${DOCKER_PLATFORMS} --push
+        - >-
+          /tmp/scripts.sh push_readme
+          ${TRAVIS_REPO_SLUG} README.md
+          ${DOCKER_USERNAME} ${DOCKER_PASSWORD}
+notifications:
+  email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from apline, a minimal docker image
-FROM alpine:latest
+FROM --platform=$BUILDPLATFORM alpine:latest
 
 # Add in SSL certificates for use with https, curl to call the update endpoint,
 # bash used by the namecheap-ddns-update script, and gawk to parse the response

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ This example runs every hour (1h) to update the IP address to the callers public
 ```
 
 ### Docker
+
+This docker container should be available from _gdunstone/namecheap-ddns-update_
+
+```
+docker run -e "NC_DDNS_PASS=123456" -e "DOMAIN=example.com" -e "SUBDOMAINS=abc,xyz" -e "INTERVAL=10s" -d --name nc-ddns gdunstone/namecheap-ddns-update
+```
+
+### Old docker instructions
+
 You can also run this from within a Docker container.
 
 Build your namecheap-ddns-update docker image

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # namecheap-ddns-update
 Update the IP address of your [namecheap.com](namecheap.com) Dynamic DNS A records.
 
+[![Build Status](https://travis-ci.com/gdunstone/namecheap-ddns-update.svg?branch=master)](https://travis-ci.com/gdunstone/namecheap-ddns-update)
+
 ## Overview
 Use this to update the IP address of A records for a domain that is hosted by [namecheap.com](namecheap.com). If you created one or more A records using [namecheap.com](namecheap.com) Dynamic DNS, then this will update the IP address to:
 * The IP address you pass in as an argument using -i


### PR DESCRIPTION
This is the setup and automated build process for multiple architectures.

This was pretty much just lifted whole cloth from https://github.com/moikot/golang-dep

@joshuamorris3 you just need to setup travis.ci with your github account & add your docker login.

This will mean that you can run this on a raspberry pi or other arm device without having to rebuild on the device.
 
Its already up on https://hub.docker.com/r/gdunstone/namecheap-ddns-update if you want to compare or try. 